### PR TITLE
[ES-300] limit length of promoting user data to 64 chars

### DIFF
--- a/lib/lita/handlers/artifactory.rb
+++ b/lib/lita/handlers/artifactory.rb
@@ -33,7 +33,8 @@ module Lita
         promotion_options = {
           status:  'STABLE',
           comment: 'Promoted using the lita-artifactory plugin. ChatOps FTW!',
-          user: "#{user.name} (ID: #{user.id}, Mention name: #{user.mention_name})",
+          # user is limited to 64 characters
+          user: "#{user.name} (#{user.id} / #{user.mention_name})"[0..63],
         }
 
         # attempt to locate the build

--- a/spec/lita/handlers/artifactory_spec.rb
+++ b/spec/lita/handlers/artifactory_spec.rb
@@ -65,6 +65,20 @@ Please verify *poop* is a valid project name and *33* is a valid version number.
         expect(replies.first).to eq(success_response)
       end
     end
+
+    context 'the promoting user data is over 66 characters long' do
+      let(:user)  { Lita::User.create('Uxxxxxxxx', name: 'Some User With A Really Long Name', mention_name: 'someuserwithareallylongname') }
+      let(:build) { double('Artifactory::Resource::Build') }
+
+      before do
+        allow(Artifactory::Resource::Build).to receive(:find).and_return(build)
+      end
+
+      it 'truncates the user data to 66 characters' do
+        expect(build).to receive(:promote).with(described_class::STABLE_REPO, hash_including(user: 'Some User With A Really Long Name (Uxxxxxxxx / someuserwithareal')).exactly(2).times.and_return('messages' => [])
+        send_command('artifactory promote angrychef 12.0.0')
+      end
+    end
   end
 
   describe '#artifactory repositories' do


### PR DESCRIPTION
If this data is longer than 64 characters Artifactory throws this wonderful
error:

```
Caused by: org.postgresql.util.PSQLException: ERROR: value too long for type character varying(64)
```