### PR TITLE
gem fetch exits 0 on failure

### DIFF
--- a/lib/lita/handlers/artifactory.rb
+++ b/lib/lita/handlers/artifactory.rb
@@ -126,12 +126,12 @@ module Lita
             %w{ruby universal-mingw32}.each do |platform|
               cmd = Mixlib::ShellOut.new(fetch_command_for_platform(platform, ruby_gem, version, gem_source))
               cmd.run_command
-              begin
-                cmd.error!
-              rescue Mixlib::ShellOut::ShellCommandFailed => e
-                response.reply(":warning: :warning: There were errors retrieving the #{human_name} from #{gem_source}! :warning: :warning:\n#{e}")
+              unless cmd.stderr.empty?
+                response.reply(":warning: :warning: There were errors retrieving the #{human_name} from #{gem_source}! :warning: :warning:\n#{cmd.stderr}")
                 missing_gem = true
+                break
               end
+              response.reply cmd.stdout
             end
 
             break if missing_gem

--- a/spec/lita/handlers/artifactory_spec.rb
+++ b/spec/lita/handlers/artifactory_spec.rb
@@ -4,14 +4,16 @@ class FakeShellout
   def initialize
     @commands = []
     @times_called = 0
+    @stderr = ""
   end
 
   attr_accessor :commands
-  attr_accessor :has_error
+  attr_accessor :stderr
   attr_reader :times_called
+  attr_reader :stdout
 
   def error!
-    raise Mixlib::ShellOut::ShellCommandFailed.new if has_error
+    raise Mixlib::ShellOut::ShellCommandFailed.new unless stderr.empty?
   end
 
   def run_command
@@ -211,7 +213,7 @@ The *angrychef* *12.0.0* build was not promoted to _current_ from _unstable_ bec
 
     context "fail to fetch a gem" do
       before do
-        shellout.has_error = true
+        shellout.stderr = "there was an error"
       end
 
       it "does not push anything to rubygems" do


### PR DESCRIPTION
Turns out failures on gem fetch exit with 0. So the command would silently fail on bogus gems since there was no error reported but also no file downloaded and therefore no success output.

This catches text from stderr on fetch and also outputs stdout on a successful fetch.

I have confirmed that a failed push does return a exit code of `1`.

I used the shell adapter to test this.