### PR TITLE
Update promote message linkage for Artifactory 4

### DIFF
--- a/lib/lita/handlers/artifactory.rb
+++ b/lib/lita/handlers/artifactory.rb
@@ -114,7 +114,7 @@ module Lita
             :metal: :ice_cream: *#{project}* *#{version}* has been successfully promoted to the *#{PROMOTION_CHANNEL}* channel!
 
             You can view the promoted artifacts at:
-            #{config.endpoint}/webapp/browserepo.html?pathId=omnibus-#{PROMOTION_CHANNEL}-local:#{artifact_path}
+            #{config.endpoint}/webapp/#/artifacts/browse/tree/General/omnibus-#{PROMOTION_CHANNEL}-local/#{artifact_path}
           EOH
         rescue ::Artifactory::Error::HTTPError => e
           reply_msg = <<-EOH.gsub(/^ {12}/, "")

--- a/spec/lita/handlers/artifactory_spec.rb
+++ b/spec/lita/handlers/artifactory_spec.rb
@@ -109,7 +109,7 @@ describe Lita::Handlers::Artifactory, lita_handler: true do
 :metal: :ice_cream: *angrychef* *12.0.0* has been successfully promoted to the *stable* channel!
 
 You can view the promoted artifacts at:
-http://artifactory.chef.fake/webapp/browserepo.html?pathId=omnibus-stable-local:com/getchef/angrychef/12.0.0
+http://artifactory.chef.fake/webapp/#/artifacts/browse/tree/General/omnibus-stable-local/com/getchef/angrychef/12.0.0
       EOH
       expect(replies.first).to eq(success_response)
     end


### PR DESCRIPTION
Previous linkage would 404-no-soup-for-you with the newer version of Artifactory.

```
{
  "errors" : [ {
    "status" : 404,
    "message" : "Not Found"
  } ]
}
```
