### PR TITLE
[JEX-327] Artifacts may exist in multiple current channel repos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,12 @@ PATH
     lita-artifactory (0.0.1)
       artifactory (>= 2.3.0)
       lita (>= 4.0)
+      mixlib-shellout
 
 GEM
   remote: https://rubygems.org/
   specs:
-    artifactory (2.3.2)
+    artifactory (2.5.0)
     ast (2.2.0)
     chefstyle (0.3.1)
       rubocop (= 0.39.0)
@@ -20,7 +21,7 @@ GEM
       url_mount (~> 0.2.1)
     i18n (0.7.0)
     ice_nine (0.11.2)
-    lita (4.7.0)
+    lita (4.7.1)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
       http_router (>= 0.11.2)
@@ -28,23 +29,24 @@ GEM
       ice_nine (>= 0.11.0)
       multi_json (>= 1.7.7)
       puma (>= 2.7.1)
-      rack (>= 1.5.2)
+      rack (>= 1.5.2, < 2.0.0)
       rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
-    multi_json (1.11.3)
+    mixlib-shellout (2.2.7)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     parser (2.3.0.7)
       ast (~> 2.2)
     powerpack (0.1.1)
-    puma (3.4.0)
+    puma (3.6.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.1.0)
     rake (10.4.2)
     rb-readline (0.5.3)
-    redis (3.3.0)
+    redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     rspec (3.2.0)
@@ -85,4 +87,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.6
+   1.12.3

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,10 @@ require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new
-RuboCop::RakeTask.new
 
-task default: [:spec, :rubocop]
+desc " Run ChefStyle"
+RuboCop::RakeTask.new(:chefstyle) do |task|
+  task.options << "--display-cop-names"
+end
+
+task default: [:spec, :chefstyle]

--- a/lib/lita/handlers/artifactory.rb
+++ b/lib/lita/handlers/artifactory.rb
@@ -87,8 +87,8 @@ module Lita
           return
         end
 
-        # Validate the artifacts all exist in `omnibus-current-local`
-        unless repos_for(build).all? { |r| r == "omnibus-current-local" }
+        # Validate the artifacts only exist in the current channel
+        unless repos_for(build).all? { |r| r =~ /current/ }
           reply_msg = <<-EOH.gsub(/^ {12}/, "")
             :hankey: *#{project}* *#{version}* does not exist in the _current_ channel.
 


### PR DESCRIPTION
Now that we have deployed APT/YUM repos in Artifactory (see JEX-186, JEX-187) we need to relax our current channel validation check to allow a builds's artifacts to exist in any of the following repos:

* omnibus-current-local - The existing generic repo
* current-apt-local - The new APT repo
* current-yum-local - The new YUM repo
* current-migration-local - Temp repo used for migrating to new APT/YUM repos

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @chef/engineering-services 