### PR TITLE
Add `artifactory_artifact_promoted` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ artifactory gem push <gem_name> <version>
 
 artifactory repos # list all the artifact repositories under the base path
 ````
+
+## Consuming the `artifactory_artifact_promoted` event
+When an artifact is successfully promoted from the *current* to *stable* channel,
+a `artifactory_artifact_promoted` event is published. If you wish to trigger
+behavior in your Lita plugin when certain projects are promoted, you can
+write an [event route](https://docs.lita.io/plugin-authoring/handlers/#event-routes)
+that will listen for that event.
+
 ## Local Testing With the Shell Adapter
 ### Install redis
 ````

--- a/lib/lita/handlers/artifactory.rb
+++ b/lib/lita/handlers/artifactory.rb
@@ -126,6 +126,11 @@ module Lita
           EOH
         end
 
+        # This event allows other lita utilities to act when projects are promoted.
+        robot.trigger(:artifactory_artifact_promoted, product: project, version: version, target_channel: PROMOTION_CHANNEL, source_channel: source_channel(PROMOTION_CHANNEL))
+
+        # The dockerbus promote should probably be deprecated when lita-dockerbus
+        # is modified to trigger based off the generic artifactory_promote.
         robot.trigger(:dockerbus_promote, product: project, version: version)
 
         response.reply reply_msg
@@ -172,6 +177,14 @@ module Lita
       end
 
       private
+
+      def source_channel(target_channel)
+        case target_channel
+        when "current"; "unstable"
+        when "stable"; "current"
+        else raise "Source channel is not known for target channel: #{target_channel}"
+        end
+      end
 
       def client
         @client ||= ::Artifactory::Client.new(


### PR DESCRIPTION
When a product is promoted, trigger an `artifactory_artifact_promoted` event that can be consumed by other Lita plugins such as lita-versioner or lita-dockerbus.

This lays the ground work for a more holistic pub-sub model within our ecosystem. 